### PR TITLE
Configurable ghost area

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ If you would like to get involved, see the twiki for [the JetMET working group f
   - [`JetReclusteringTool` tool](#jetreclusteringtool-tool)
   - [`JetReclusteringAlgo` algorithm](#jetreclusteringalgo-algorithm)
 - [Using xAOD Jet Reclustering](#using-xaod-jet-reclustering)
+  - [Input Jet Filtering](#input-jet-filtering)
+  - [Output Reclustered Jet Trimming](#output-reclustered-jet-trimming)
   - [Variable-R Jet Finding](#variable-r-jet-finding)
+  - [Area Calculations](#area-calculations)
   - [Incorporating in existing code](#incorporating-in-existing-code)
   - [Incorporating in algorithm chain](#incorporating-in-algorithm-chain)
 - [Studies and Example Usage](#studies-and-example-usage)
@@ -49,24 +52,28 @@ RCJetPtMin          | float                     | 50.0                      | fi
 RCJetPtFrac         | float                     | 0.05                      | trim the reclustered jets with a PtFrac on its constituents (eg: small-R input jets)
 VariableRMinRadius  | float                     | -1.0                      | minimum radius for variable-R jet finding
 VariableRMassScale  | float                     | -1.0                      | mass scale [GeV] for variable-R jet finding
+DoArea              | bool                      | false                     | turn on ghost area calculations (set ghost area scale to 0.01)
+AreaAttributes      | string                    | ActiveArea ActiveArea4vec | space-delimited list of attributes to transfer over from fastjet
 
 ### `JetReclusteringAlgo` algorithm
 
 As well as the provided above configurations for the `JetReclusteringTool`, we also provide a `m_debug` configuration for extra verbose output and an `m_outputXAODName` to create an output xAOD containing the reclustered jets (note: experimental)
 
-Variable            | Type      | Default           | Description
-:-------------------|:---------:|------------------:|:-------------------------------------------------------------------------------------
-m_inputJetContainer | string    |                   | see above
-m_outputJetContainer| string    |                   | see above
-m_ptMin_input       | float     | 25.0              | see above
-m_rc_algName        | string    | antikt_algorithm  | see above
-m_radius            | float     | 1.0               | see above
-m_ptMin_rc          | float     | 50.0              | see above
-m_ptFrac            | float     | 0.05              | see above
-m_varR_minR         | float     | -1.0              | see above
-m_varR_mass         | float     | -1.0              | see above
-m_outputXAODName    | string    |                   | if defined, put the reclustered jets in an output xAOD file of the given name
-m_debug             | bool      | false             | enable verbose debugging information, such as printing the tool configurations
+Variable            | Type      | Default                   | Description
+:-------------------|:---------:|--------------------------:|:-------------------------------------------------------------------------------------
+m_inputJetContainer | string    |                           | see above
+m_outputJetContainer| string    |                           | see above
+m_ptMin_input       | float     | 25.0                      | see above
+m_rc_algName        | string    | antikt_algorithm          | see above
+m_radius            | float     | 1.0                       | see above
+m_ptMin_rc          | float     | 50.0                      | see above
+m_ptFrac            | float     | 0.05                      | see above
+m_varR_minR         | float     | -1.0                      | see above
+m_varR_mass         | float     | -1.0                      | see above
+m_doArea            | bool      | false                     | see above
+m_areaAttributes    | string    | ActiveArea ActiveArea4vec | see above
+m_outputXAODName    | string    |                           | if defined, put the reclustered jets in an output xAOD file of the given name
+m_debug             | bool      | false                     | enable verbose debugging information, such as printing the tool configurations
 
 ## Using xAOD Jet Reclustering
 
@@ -96,6 +103,13 @@ ReclusterRadius     | float                     | SizeParameter
 VariableRMinRadius  | float                     | VariableRMinRadius
 VariableRMassScale  | float                     | VariableRMassScale
                     | float                     | EffectiveR
+
+### Area Calculations
+
+Areas can be calculated and added to the jets. Fastjet does the area calculation and these values can be transferred over using the `JetFromPseudojet` tool. To make this happen, simply enable `m_doArea` (`DoArea`) which will set the ghost area size to `0.01` which is a reasonable default for most use cases. The attributes that get transferred over are defined in `m_areaAttributes` (`AreaAttributes`). As of the time of writing this section of the README, there were only two allowed values which would get decorated:
+
+- `ActiveArea` (most people use this one)
+- `ActiveArea4vec`
 
 ### Incorporating in existing code
 

--- a/Root/JetReclusteringAlgo.cxx
+++ b/Root/JetReclusteringAlgo.cxx
@@ -78,6 +78,7 @@ EL::StatusCode JetReclusteringAlgo :: initialize ()
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("InputJetPtMin",      m_ptMin_input), "");
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("RCJetPtMin",         m_ptMin_rc), "");
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("RCJetPtFrac",        m_ptFrac), "");
+  RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("GhostArea",          m_ghostArea), "");
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->initialize(), "");
 
   if(m_debug) m_jetReclusteringTool->print();

--- a/Root/JetReclusteringAlgo.cxx
+++ b/Root/JetReclusteringAlgo.cxx
@@ -78,7 +78,8 @@ EL::StatusCode JetReclusteringAlgo :: initialize ()
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("InputJetPtMin",      m_ptMin_input), "");
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("RCJetPtMin",         m_ptMin_rc), "");
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("RCJetPtFrac",        m_ptFrac), "");
-  RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("Area",               m_area), "");
+  RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("DoArea",             m_doArea), "");
+  RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("AreaAttributes",     m_areaAttributes), "");
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->initialize(), "");
 
   if(m_debug) m_jetReclusteringTool->print();

--- a/Root/JetReclusteringAlgo.cxx
+++ b/Root/JetReclusteringAlgo.cxx
@@ -78,7 +78,7 @@ EL::StatusCode JetReclusteringAlgo :: initialize ()
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("InputJetPtMin",      m_ptMin_input), "");
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("RCJetPtMin",         m_ptMin_rc), "");
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("RCJetPtFrac",        m_ptFrac), "");
-  RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("GhostArea",          m_ghostArea), "");
+  RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->setProperty("Area",               m_area), "");
   RETURN_CHECK("JetReclusteringAlgo::initialize()", m_jetReclusteringTool->initialize(), "");
 
   if(m_debug) m_jetReclusteringTool->print();

--- a/Root/JetReclusteringTool.cxx
+++ b/Root/JetReclusteringTool.cxx
@@ -83,10 +83,10 @@ StatusCode JetReclusteringTool::initialize(){
 
   // only compute area if ptFrac = 0.0 and m_area is specified
   float ghostArea(0.0);
+  std::vector<std::string> areaAttributes;
   if(m_ptFrac == 0.0 && !m_area.empty()){
     ghostArea = 0.01;
     // split up the m_area string specifying which attributes to record
-    std::vector<std::string> areaAttributes;
     std::string token;
     std::istringstream ss(m_area);
     while(std::getline(ss, token, ' '))

--- a/Root/JetReclusteringTool.cxx
+++ b/Root/JetReclusteringTool.cxx
@@ -39,7 +39,8 @@ JetReclusteringTool::JetReclusteringTool(std::string name) :
   declareProperty("InputJetPtMin",      m_ptMin_input = 25.0);
   declareProperty("RCJetPtMin",         m_ptMin_rc = 50.0);
   declareProperty("RCJetPtFrac",        m_ptFrac = 0.05);
-  declareProperty("Area",               m_area = "");
+  declareProperty("DoArea",             m_doArea = false);
+  declareProperty("AreaAttributes",     m_areaAttributes = "ActiveArea ActiveArea4vec");
 }
 
 StatusCode JetReclusteringTool::initialize(){
@@ -81,14 +82,12 @@ StatusCode JetReclusteringTool::initialize(){
     CHECK(prettyFuncName, m_inputJetFilterTool->initialize());
   }
 
-  // only compute area if ptFrac = 0.0 and m_area is specified
-  float ghostArea(0.0);
+  // only compute area if ptFrac = 0.0 and m_areaAttributes is specified
   std::vector<std::string> areaAttributes;
-  if(m_ptFrac == 0.0 && !m_area.empty()){
-    ghostArea = 0.01;
-    // split up the m_area string specifying which attributes to record
+  if(m_doArea){
+    // split up the m_areaAttributes string specifying which attributes to record
     std::string token;
-    std::istringstream ss(m_area);
+    std::istringstream ss(m_areaAttributes);
     while(std::getline(ss, token, ' '))
       areaAttributes.push_back(token);
   }
@@ -112,7 +111,7 @@ StatusCode JetReclusteringTool::initialize(){
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("VariableRMassScale", m_varR_mass*1.e3));
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("PtMin", m_ptMin_rc*1.e3));
   // set ghost area, ignore if trimming is being applied to reclustered jets
-  CHECK(prettyFuncName, m_jetFinderTool->setProperty("GhostArea", ghostArea));
+  CHECK(prettyFuncName, m_jetFinderTool->setProperty("GhostArea", 0.0));
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("RandomOption", 1));
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("JetBuilder", ToolHandle<IJetFromPseudojet>(m_jetFromPseudoJetTool.get())));
   CHECK(prettyFuncName, m_jetFinderTool->initialize());

--- a/Root/JetReclusteringTool.cxx
+++ b/Root/JetReclusteringTool.cxx
@@ -37,6 +37,7 @@ JetReclusteringTool::JetReclusteringTool(std::string name) :
   declareProperty("InputJetPtMin",      m_ptMin_input = 25.0);
   declareProperty("RCJetPtMin",         m_ptMin_rc = 50.0);
   declareProperty("RCJetPtFrac",        m_ptFrac = 0.05);
+  declareProperty("GhostArea",          m_ghostArea = 0.01);
 }
 
 StatusCode JetReclusteringTool::initialize(){
@@ -95,7 +96,9 @@ StatusCode JetReclusteringTool::initialize(){
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("VariableRMinRadius", m_varR_minR));
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("VariableRMassScale", m_varR_mass*1.e3));
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("PtMin", m_ptMin_rc*1.e3));
-  CHECK(prettyFuncName, m_jetFinderTool->setProperty("GhostArea", 0.0));
+  // set ghost area, ignore if trimming is being applied to reclustered jets
+  if(m_ptFrac > 0.0) m_ghostArea = 0.0;
+  CHECK(prettyFuncName, m_jetFinderTool->setProperty("GhostArea", m_ghostArea));
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("RandomOption", 1));
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("JetBuilder", ToolHandle<IJetFromPseudojet>(m_jetFromPseudoJetTool.get())));
   CHECK(prettyFuncName, m_jetFinderTool->initialize());

--- a/Root/JetReclusteringTool.cxx
+++ b/Root/JetReclusteringTool.cxx
@@ -86,7 +86,7 @@ StatusCode JetReclusteringTool::initialize(){
   if(m_ptFrac == 0.0 && !m_area.empty()){
     ghostArea = 0.01;
     // split up the m_area string specifying which attributes to record
-    std::vector<std::string> areaAttributes();
+    std::vector<std::string> areaAttributes;
     std::string token;
     std::istringstream ss(m_area);
     while(std::getline(ss, token, ' '))

--- a/Root/JetReclusteringTool.cxx
+++ b/Root/JetReclusteringTool.cxx
@@ -83,8 +83,10 @@ StatusCode JetReclusteringTool::initialize(){
   }
 
   // only compute area if ptFrac = 0.0 and m_areaAttributes is specified
+  float ghostArea(0.0);
   std::vector<std::string> areaAttributes;
   if(m_doArea){
+    ghostArea = 0.01;
     // split up the m_areaAttributes string specifying which attributes to record
     std::string token;
     std::istringstream ss(m_areaAttributes);
@@ -111,7 +113,7 @@ StatusCode JetReclusteringTool::initialize(){
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("VariableRMassScale", m_varR_mass*1.e3));
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("PtMin", m_ptMin_rc*1.e3));
   // set ghost area, ignore if trimming is being applied to reclustered jets
-  CHECK(prettyFuncName, m_jetFinderTool->setProperty("GhostArea", 0.0));
+  CHECK(prettyFuncName, m_jetFinderTool->setProperty("GhostArea", ghostArea));
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("RandomOption", 1));
   CHECK(prettyFuncName, m_jetFinderTool->setProperty("JetBuilder", ToolHandle<IJetFromPseudojet>(m_jetFromPseudoJetTool.get())));
   CHECK(prettyFuncName, m_jetFinderTool->initialize());

--- a/xAODJetReclustering/JetReclusteringAlgo.h
+++ b/xAODJetReclustering/JetReclusteringAlgo.h
@@ -27,7 +27,7 @@ public:
   float m_ptFrac = 0.05;
   float m_varR_minR = -1.0;
   float m_varR_mass = -1.0; // GeV
-  float m_ghostArea = 0.01;
+  std::string m_area = "";
   bool m_debug = false;
 
 private:

--- a/xAODJetReclustering/JetReclusteringAlgo.h
+++ b/xAODJetReclustering/JetReclusteringAlgo.h
@@ -27,7 +27,8 @@ public:
   float m_ptFrac = 0.05;
   float m_varR_minR = -1.0;
   float m_varR_mass = -1.0; // GeV
-  std::string m_area = "";
+  bool m_doArea = false;
+  std::string m_areaAttributes = "ActiveArea ActiveArea4vec";
   bool m_debug = false;
 
 private:

--- a/xAODJetReclustering/JetReclusteringAlgo.h
+++ b/xAODJetReclustering/JetReclusteringAlgo.h
@@ -27,6 +27,7 @@ public:
   float m_ptFrac = 0.05;
   float m_varR_minR = -1.0;
   float m_varR_mass = -1.0; // GeV
+  float m_ghostArea = 0.01;
   bool m_debug = false;
 
 private:

--- a/xAODJetReclustering/JetReclusteringTool.h
+++ b/xAODJetReclustering/JetReclusteringTool.h
@@ -84,8 +84,9 @@ class JetReclusteringTool : virtual public asg::AsgTool {
     float m_ptMin_rc;
     // trimming to apply to reclustered jets
     float m_ptFrac;
-    // ghost area of jet (only used if m_ptFrac == 0)
-    float m_ghostArea;
+    // if this is not empty, we want to enable area calculations
+    //   - only used if m_ptFrac == 0
+    std::string m_area;
 
     // make sure someone only calls a function once
     bool m_isInitialized = false;

--- a/xAODJetReclustering/JetReclusteringTool.h
+++ b/xAODJetReclustering/JetReclusteringTool.h
@@ -84,9 +84,9 @@ class JetReclusteringTool : virtual public asg::AsgTool {
     float m_ptMin_rc;
     // trimming to apply to reclustered jets
     float m_ptFrac;
-    // if this is not empty, we want to enable area calculations
-    //   - only used if m_ptFrac == 0
-    std::string m_area;
+    // enable to add area attributes form
+    bool m_doArea;
+    std::string m_areaAttributes;
 
     // make sure someone only calls a function once
     bool m_isInitialized = false;

--- a/xAODJetReclustering/JetReclusteringTool.h
+++ b/xAODJetReclustering/JetReclusteringTool.h
@@ -84,6 +84,8 @@ class JetReclusteringTool : virtual public asg::AsgTool {
     float m_ptMin_rc;
     // trimming to apply to reclustered jets
     float m_ptFrac;
+    // ghost area of jet (only used if m_ptFrac == 0)
+    float m_ghostArea;
 
     // make sure someone only calls a function once
     bool m_isInitialized = false;


### PR DESCRIPTION
As explained, now add two new tool options:

```
m_doArea
m_areaAttributes
```

The former will enable area calculations saving the area attributes defined in `m_areaAttributes` (such as `ActiveArea` and `ActiveArea4vec`.

/cc @AvivCukierman
