### PR TITLE
Correcting ghostTrackVertexAssociationName

### DIFF
--- a/JetReclustering/JetReclusteringTool.h
+++ b/JetReclustering/JetReclusteringTool.h
@@ -71,7 +71,7 @@ class JetReclusteringTool : public asg::AsgTool, virtual public IJetExecuteTool 
     std::string m_areaAttributes;
   /* for ghost tracks */
     std::string m_ghostTracksInputContainer;
-    std::string m_ghostTracksVertexAssName;
+    std::string m_ghostTracksVertexAssociationName;
     float m_ghostScale;
 
     // make sure someone only calls a function once

--- a/Root/JetReclusteringTool.cxx
+++ b/Root/JetReclusteringTool.cxx
@@ -68,7 +68,7 @@ JetReclusteringTool::JetReclusteringTool(std::string name) :
   declareProperty("DoArea",                    m_doArea = false);
   declareProperty("AreaAttributes",            m_areaAttributes = "ActiveArea ActiveArea4vec");
   declareProperty("GhostTracksInputContainer", m_ghostTracksInputContainer = "");
-  declareProperty("GhostTracksVertexAssName",  m_ghostTracksVertexAssName = "");
+  declareProperty("GhostTracksVertexAssociationName",  m_ghostTracksVertexAssociationName = "");
   declareProperty("GhostScale",                m_ghostScale = 1e-20);
 
 }
@@ -163,7 +163,7 @@ StatusCode JetReclusteringTool::initialize(){
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("Label", "GhostTrack"));
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("SkipNegativeEnergy", true));
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("GhostScale", m_ghostScale));
-    ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("TrackVertexAssociation", m_ghostTracksVertexAssName));
+    ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("TrackVertexAssociation", m_ghostTracksVertexAssociationName));
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("OutputLevel", msg().level() ) );
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.retrieve());
     getterArray.push_back(m_pseudoGhostTrackJetGetterTool.getHandle());


### PR DESCRIPTION
Changes variable names m_ghostTrackVertexAssociationName to remain consistent and remove errors. 