### PR TITLE
Ghost tracks and truth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,64 @@
-#to be completed
-# another fake comment
+
+# The name of the package:
+atlas_subdir( JetReclustering )
+
+# Dependency helper variable:
+set( extra_deps )
+if( XAOD_STANDALONE )
+   set( extra_deps Control/xAODRootAccess
+      PhysicsAnalysis/D3PDTools/EventLoop PRIVATE Event/xAOD/xAODEventInfo
+      Reconstruction/Jet/JetSubStructureMomentTools )
+else()
+   set( extra_deps PRIVATE Control/xAODRootAccess Control/AthenaBaseComps
+      PhysicsAnalysis/POOLRootAccess GaudiKernel )
+endif()
+
+# The dependencies of the package:
+atlas_depends_on_subdirs(
+   PUBLIC
+   Control/AthToolSupport/AsgTools
+   Reconstruction/Jet/JetInterface
+   Reconstruction/Jet/JetRec
+   ${extra_deps}
+   Event/xAODJet )
+
+# Libraries in the package:
+if( XAOD_STANDALONE )
+   atlas_add_root_dictionary( JetReclusteringLib JetReclusteringCintDict
+      ROOT_HEADERS JetReclustering/JetReclusteringAlgo.h Root/LinkDef.h
+      EXTERNAL_PACKAGES ROOT )
+
+   atlas_add_library( JetReclusteringLib
+      JetReclustering/*.h Root/*.cxx ${JetReclusteringCintDict}
+      PUBLIC_HEADERS JetReclustering
+      LINK_LIBRARIES AsgTools JetInterface JetRecLib xAODRootAccess EventLoop
+      PRIVATE_LINK_LIBRARIES xAODJet xAODEventInfo
+      JetSubStructureMomentToolsLib )
+else()
+   atlas_add_library( JetReclusteringLib
+      JetReclustering/*.h Root/*.cxx
+      PUBLIC_HEADERS JetReclustering
+      LINK_LIBRARIES AsgTools JetInterface JetRecLib
+      PRIVATE_LINK_LIBRARIES xAODJet xAODRootAccess )
+
+   atlas_add_component( JetReclustering
+      src/*.h src/*.cxx src/components/*.cxx
+      LINK_LIBRARIES AthenaBaseComps GaudiKernel JetInterface
+      JetReclusteringLib )
+endif()
+
+atlas_add_dictionary( JetReclusteringDict
+   JetReclustering/JetReclusteringDict.h
+   JetReclustering/selection.xml
+   LINK_LIBRARIES JetReclusteringLib )
+
+# Test(s) in the package:
+if( NOT XAOD_STANDALONE )
+   atlas_add_test( ut_JetReclusteringTool_test
+      SOURCES test/ut_JetReclusteringTool_test.cxx
+      LINK_LIBRARIES xAODRootAccess AsgTools JetInterface xAODJet
+      POOLRootAccess )
+endif()
+
+# Install files from the package:
+atlas_install_joboptions( share/*.py )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 # The name of the package:
 atlas_subdir( JetReclustering )
 
@@ -53,12 +52,15 @@ atlas_add_dictionary( JetReclusteringDict
    LINK_LIBRARIES JetReclusteringLib )
 
 # Test(s) in the package:
+set( extra_libs )
 if( NOT XAOD_STANDALONE )
-   atlas_add_test( ut_JetReclusteringTool_test
-      SOURCES test/ut_JetReclusteringTool_test.cxx
-      LINK_LIBRARIES xAODRootAccess AsgTools JetInterface xAODJet
-      POOLRootAccess )
+   set( extra_libs POOLRootAccessLib )
 endif()
+atlas_add_test( ut_JetReclusteringTool_test
+                SOURCES test/ut_JetReclusteringTool_test.cxx
+                INCLUDE_DIRS ${ROOT_INCLUDE_DIRS}
+                LINK_LIBRARIES ${ROOT_LIBRARIES} xAODRootAccess AsgTools JetInterface xAODJet
+                ${extra_libs} )
 
 # Install files from the package:
 atlas_install_joboptions( share/*.py )

--- a/JetReclustering/JetReclusteringTool.h
+++ b/JetReclustering/JetReclusteringTool.h
@@ -71,9 +71,11 @@ class JetReclusteringTool : public asg::AsgTool, virtual public IJetExecuteTool 
     std::string m_areaAttributes;
   /* for ghost tracks */
     std::string m_ghostTracksInputContainer;
-    std::string m_ghostTracksVertexAssociationName;
     float m_ghostScale;
-
+std::string m_ghostTracksVertexAssName;
+  /* for truth matching */
+    std::string m_ghostTruthInputBContainer;
+    std::string m_ghostTruthInputCContainer;
     // make sure someone only calls a function once
     bool m_isInitialized = false;
     // this is for filtering input jets
@@ -82,6 +84,8 @@ class JetReclusteringTool : public asg::AsgTool, virtual public IJetExecuteTool 
     // this is for reclustering using filtered input jets
     asg::AnaToolHandle<IPseudoJetGetter> m_pseudoJetGetterTool;
     asg::AnaToolHandle<IPseudoJetGetter> m_pseudoGhostTrackJetGetterTool;
+    asg::AnaToolHandle<IPseudoJetGetter> m_pseudoTruthParticleBJetGetterTool;
+    asg::AnaToolHandle<IPseudoJetGetter> m_pseudoTruthParticleCJetGetterTool;
     asg::AnaToolHandle<IJetFromPseudojet> m_jetFromPseudoJetTool;
     asg::AnaToolHandle<IJetFinder> m_jetFinderTool;
     asg::AnaToolHandle<IJetExecuteTool> m_reclusterJetTool;

--- a/JetReclustering/JetReclusteringTool.h
+++ b/JetReclustering/JetReclusteringTool.h
@@ -71,7 +71,7 @@ class JetReclusteringTool : public asg::AsgTool, virtual public IJetExecuteTool 
     std::string m_areaAttributes;
   /* for ghost tracks */
     std::string m_ghostTracksInputContainer;
-    std::string m_ghostTracksVertexAssName;
+    std::string m_ghostTracksVertexAssociationName;
     float m_ghostScale;
 
     // make sure someone only calls a function once

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 *This is currently in AnalysisBase releases 2.4.17+.*
 
+*This is an updated README for the ghostTracks branch which allows ghost association of tracks to the reclustered, large R jets, there is simply a few more options that must be specified --the name of the TrackContainer and TrackVertexAssociationTool.  Note for this to not crash, a TrackVertexAssociationTool must exist already!!!*
+
+*The new ghost association implementation is only for Athena right now, there is no RootCore equivalent.*
+
 This tool allows you to recluster small-R xAOD jets into large-R xAOD jets. It provides configurable filtering of the small-R jets, reclustering using standard or variable-R algorithms, configurable trimming of the large-R jets, and jet moment & jet substructure moment calculations.
 
 If you would like to get involved, see the twiki for [the JetMET working group for jet reclustering](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JetReclustering). The [pre-recommendations](https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/PreRec) twiki contains the guidelines for your analyses.
@@ -64,7 +68,8 @@ VariableRMinRadius  | float                     | -1.0                      | mi
 VariableRMassScale  | float                     | -1.0                      | mass scale [GeV] for variable-R jet finding
 DoArea              | bool                      | false                     | turn on ghost area calculations (set ghost area scale to 0.01)
 AreaAttributes      | string                    | ActiveArea ActiveArea4vec | space-delimited list of attributes to transfer over from fastjet
-
+GhostTracksInputContainer | string              |                           | name of TrackContainer used for ghost association
+GhostTracksVertexAssociationName | string       |                           | name of TrackVertexAssociationTool, must be created already in order not to crash!
 ### `JetReclusteringAlgo` algorithm
 
 As well as the provided above configurations for the `JetReclusteringTool`, we also provide a `m_debug` configuration for extra verbose output and an `m_outputXAODName` to create an output xAOD containing the reclustered jets (note: experimental)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 *This is currently in AnalysisBase releases 2.4.17+.*
 
-*This is an updated README for the ghostTracks branch which allows ghost association of tracks to the reclustered, large R jets, there is simply a few more options that must be specified --the name of the TrackContainer and TrackVertexAssociationTool.  Note for this to not crash, a TrackVertexAssociationTool must exist already!!!*
-
-*The new ghost association implementation is only for Athena right now, there is no RootCore equivalent.*
-
 This tool allows you to recluster small-R xAOD jets into large-R xAOD jets. It provides configurable filtering of the small-R jets, reclustering using standard or variable-R algorithms, configurable trimming of the large-R jets, and jet moment & jet substructure moment calculations.
 
 If you would like to get involved, see the twiki for [the JetMET working group for jet reclustering](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JetReclustering). The [pre-recommendations](https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/PreRec) twiki contains the guidelines for your analyses.
@@ -55,7 +51,6 @@ rc compile
 
 ### `JetReclusteringTool` tool
 
-<<<<<<< HEAD
  Property                 | Type                      | Default                   | Description
 :-------------------------|:-------------------------:|--------------------------:|:-------------------------------------------------------------------------------------
 InputJetContainer         | string                    |                           | name of the input jet container for reclustering
@@ -74,24 +69,6 @@ GhostTracksInputContainer | string                    |                         
 GhostTracksVertexAssName  | string                    |                           | if GhostTracksInputContainer is set, this must also be set
 GhostScale                | float                     | 1e-20                     | GhostScale for the GhostTracksInputContainer
 
-=======
- Property           | Type                      | Default                   | Description
-:-------------------|:-------------------------:|--------------------------:|:-------------------------------------------------------------------------------------
-InputJetContainer   | string                    |                           | name of the input jet container for reclustering
-OutputJetContainer  | string                    |                           | name of the output jet container holding reclustered jets
-InputJetPtMin       | float                     | 25.0                      | filter input jets by requiring a minimum pt cut [GeV]
-ReclusterAlgorithm  | string                    | AntiKt                    | name of algorithm for clustering large-R jets {AntiKt, Kt, CamKt}
-ReclusterRadius     | float                     | 1.0                       | radius of large-R reclustered jets or maximum radius of variable-R jet finding
-RCJetPtMin          | float                     | 50.0                      | filter reclustered jets by requiring a minimum pt cut [GeV]
-RCJetPtFrac         | float                     | 0.05                      | trim the reclustered jets with a PtFrac on its constituents (eg: small-R input jets)
-RCJetSubjetRadius   | float                     | 0.0                       | radius parameter for kt-clustering to form subjets (R=0.0 should not do any clustering)
-VariableRMinRadius  | float                     | -1.0                      | minimum radius for variable-R jet finding
-VariableRMassScale  | float                     | -1.0                      | mass scale [GeV] for variable-R jet finding
-DoArea              | bool                      | false                     | turn on ghost area calculations (set ghost area scale to 0.01)
-AreaAttributes      | string                    | ActiveArea ActiveArea4vec | space-delimited list of attributes to transfer over from fastjet
-GhostTracksInputContainer | string              |                           | name of TrackContainer used for ghost association
-GhostTracksVertexAssociationName | string       |                           | name of TrackVertexAssociationTool, must be created already in order not to crash!
->>>>>>> origin/master
 ### `JetReclusteringAlgo` algorithm
 
 As well as the provided above configurations for the `JetReclusteringTool`, we also provide a `m_debug` configuration for extra verbose output and an `m_outputXAODName` to create an output xAOD containing the reclustered jets (note: experimental)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 *This is currently in AnalysisBase releases 2.4.17+.*
 
+*This is an updated README for the ghostTracks branch which allows ghost association of tracks to the reclustered, large R jets, there is simply a few more options that must be specified --the name of the TrackContainer and TrackVertexAssociationTool.  Note for this to not crash, a TrackVertexAssociationTool must exist already!!!*
+
+*The new ghost association implementation is only for Athena right now, there is no RootCore equivalent.*
+
 This tool allows you to recluster small-R xAOD jets into large-R xAOD jets. It provides configurable filtering of the small-R jets, reclustering using standard or variable-R algorithms, configurable trimming of the large-R jets, and jet moment & jet substructure moment calculations.
 
 If you would like to get involved, see the twiki for [the JetMET working group for jet reclustering](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JetReclustering). The [pre-recommendations](https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/PreRec) twiki contains the guidelines for your analyses.
@@ -51,6 +55,7 @@ rc compile
 
 ### `JetReclusteringTool` tool
 
+<<<<<<< HEAD
  Property                 | Type                      | Default                   | Description
 :-------------------------|:-------------------------:|--------------------------:|:-------------------------------------------------------------------------------------
 InputJetContainer         | string                    |                           | name of the input jet container for reclustering
@@ -69,6 +74,24 @@ GhostTracksInputContainer | string                    |                         
 GhostTracksVertexAssName  | string                    |                           | if GhostTracksInputContainer is set, this must also be set
 GhostScale                | float                     | 1e-20                     | GhostScale for the GhostTracksInputContainer
 
+=======
+ Property           | Type                      | Default                   | Description
+:-------------------|:-------------------------:|--------------------------:|:-------------------------------------------------------------------------------------
+InputJetContainer   | string                    |                           | name of the input jet container for reclustering
+OutputJetContainer  | string                    |                           | name of the output jet container holding reclustered jets
+InputJetPtMin       | float                     | 25.0                      | filter input jets by requiring a minimum pt cut [GeV]
+ReclusterAlgorithm  | string                    | AntiKt                    | name of algorithm for clustering large-R jets {AntiKt, Kt, CamKt}
+ReclusterRadius     | float                     | 1.0                       | radius of large-R reclustered jets or maximum radius of variable-R jet finding
+RCJetPtMin          | float                     | 50.0                      | filter reclustered jets by requiring a minimum pt cut [GeV]
+RCJetPtFrac         | float                     | 0.05                      | trim the reclustered jets with a PtFrac on its constituents (eg: small-R input jets)
+RCJetSubjetRadius   | float                     | 0.0                       | radius parameter for kt-clustering to form subjets (R=0.0 should not do any clustering)
+VariableRMinRadius  | float                     | -1.0                      | minimum radius for variable-R jet finding
+VariableRMassScale  | float                     | -1.0                      | mass scale [GeV] for variable-R jet finding
+DoArea              | bool                      | false                     | turn on ghost area calculations (set ghost area scale to 0.01)
+AreaAttributes      | string                    | ActiveArea ActiveArea4vec | space-delimited list of attributes to transfer over from fastjet
+GhostTracksInputContainer | string              |                           | name of TrackContainer used for ghost association
+GhostTracksVertexAssociationName | string       |                           | name of TrackVertexAssociationTool, must be created already in order not to crash!
+>>>>>>> origin/master
 ### `JetReclusteringAlgo` algorithm
 
 As well as the provided above configurations for the `JetReclusteringTool`, we also provide a `m_debug` configuration for extra verbose output and an `m_outputXAODName` to create an output xAOD containing the reclustered jets (note: experimental)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 *This is currently in AnalysisBase releases 2.4.17+.*
 
+This is updated to include ghost association for tracks and now truth particles
+
 This tool allows you to recluster small-R xAOD jets into large-R xAOD jets. It provides configurable filtering of the small-R jets, reclustering using standard or variable-R algorithms, configurable trimming of the large-R jets, and jet moment & jet substructure moment calculations.
 
 If you would like to get involved, see the twiki for [the JetMET working group for jet reclustering](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JetReclustering). The [pre-recommendations](https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/PreRec) twiki contains the guidelines for your analyses.
@@ -67,6 +69,8 @@ DoArea                    | bool                      | false                   
 AreaAttributes            | string                    | ActiveArea ActiveArea4vec | space-delimited list of attributes to transfer over from fastjet
 GhostTracksInputContainer | string                    |                           | if set, create ghost tracks for the reclustered jet of radius R using the specified container
 GhostTracksVertexAssName  | string                    |                           | if GhostTracksInputContainer is set, this must also be set
+GhostTruthInputBContainer | string                    |                           | if set, create ghost truth B-hadrons using specified container
+GhostTruthInputCContainer | string                    |                           | if set, create ghost truth C-hadrons using specified container
 GhostScale                | float                     | 1e-20                     | GhostScale for the GhostTracksInputContainer
 
 ### `JetReclusteringAlgo` algorithm

--- a/Root/JetReclusteringTool.cxx
+++ b/Root/JetReclusteringTool.cxx
@@ -37,6 +37,8 @@ JetReclusteringTool::JetReclusteringTool(std::string name) :
   m_inputJetFilterTool("JetRecTool/JetRec_InputJetFilterTool_" + this->name()),
   m_pseudoJetGetterTool("PseudoJetGetter/PseudoJetGetterTool_" + this->name()),
   m_pseudoGhostTrackJetGetterTool("TrackPseudoJetGetter/PseudoGhostTrackJetGetterTool_" + this->name()),
+  m_pseudoTruthParticleBJetGetterTool("PseudoJetGetter/PseudoJetGetterTool_BTruth_" + this->name()),
+  m_pseudoTruthParticleCJetGetterTool("PseudoJetGetter/PseudoJetGetterTool_CTruth_" + this->name()),
   m_jetFromPseudoJetTool("JetFromPseudojet/JetFromPseudoJetTool_" + this->name()),
   m_jetFinderTool("JetFinder/JetFinderTool_" + this->name()),
   m_reclusterJetTool("JetRecTool/JetRec_JetReclusterTool_" + this->name()),
@@ -68,7 +70,9 @@ JetReclusteringTool::JetReclusteringTool(std::string name) :
   declareProperty("DoArea",                    m_doArea = false);
   declareProperty("AreaAttributes",            m_areaAttributes = "ActiveArea ActiveArea4vec");
   declareProperty("GhostTracksInputContainer", m_ghostTracksInputContainer = "");
-  declareProperty("GhostTracksVertexAssociationName",  m_ghostTracksVertexAssociationName = "");
+  declareProperty("GhostTruthInputBContainer",   m_ghostTruthInputBContainer = "");
+  declareProperty("GhostTruthInputCContainer",   m_ghostTruthInputCContainer = "");
+  declareProperty("GhostTracksVertexAssName",  m_ghostTracksVertexAssName = "");
   declareProperty("GhostScale",                m_ghostScale = 1e-20);
 
 }
@@ -153,7 +157,7 @@ StatusCode JetReclusteringTool::initialize(){
   //    - do we need ghost tracks too?
   if(!m_ghostTracksInputContainer.empty()){
     ATH_MSG_INFO( "GhostTracks PseudoJet Builder initializing..." );
-    if(m_ghostTracksVertexAssociationName.empty()){
+    if(m_ghostTracksVertexAssName.empty()){
       ATH_MSG_ERROR( "You must set the GhostTracksVertexAssName as well!" );
       return StatusCode::FAILURE;
     }
@@ -163,11 +167,41 @@ StatusCode JetReclusteringTool::initialize(){
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("Label", "GhostTrack"));
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("SkipNegativeEnergy", true));
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("GhostScale", m_ghostScale));
-    ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("TrackVertexAssociation", m_ghostTracksVertexAssociationName));
+    ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("TrackVertexAssociation", m_ghostTracksVertexAssName));
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("OutputLevel", msg().level() ) );
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.retrieve());
     getterArray.push_back(m_pseudoGhostTrackJetGetterTool.getHandle());
   }
+   if(!m_ghostTruthInputBContainer.empty()){
+    // std::string truthParticleLabels;
+    // std::istringstream tss(m_ghostTruthInputContainer);
+    // while( std::getline(tss, truthParticleLabels, ',')){
+       ATH_MSG_INFO( "GhostTracks PseudoJet Builder initializing..." );
+       ASG_CHECK( ASG_MAKE_ANA_TOOL( m_pseudoTruthParticleBJetGetterTool, PseudoJetGetter) );
+       ASG_CHECK(m_pseudoTruthParticleBJetGetterTool.setProperty("InputContainer",  "TruthLabel" + m_ghostTruthInputBContainer));
+       ASG_CHECK(m_pseudoTruthParticleBJetGetterTool.setProperty("OutputContainer", "GhostBTruthParticles"+name()));
+       ASG_CHECK(m_pseudoTruthParticleBJetGetterTool.setProperty("Label", "Ghost"+ m_ghostTruthInputBContainer));
+       ASG_CHECK(m_pseudoTruthParticleBJetGetterTool.setProperty("SkipNegativeEnergy", true));
+       ASG_CHECK(m_pseudoTruthParticleBJetGetterTool.setProperty("GhostScale", m_ghostScale));
+       ASG_CHECK(m_pseudoTruthParticleBJetGetterTool.setProperty("OutputLevel", msg().level() ) );
+       ASG_CHECK(m_pseudoTruthParticleBJetGetterTool.retrieve());
+       getterArray.push_back(m_pseudoTruthParticleBJetGetterTool.getHandle());
+     //}
+   }
+   if(!m_ghostTruthInputCContainer.empty()){
+    ATH_MSG_INFO( "GhostTracks PseudoJet Builder initializing..." );
+       ASG_CHECK( ASG_MAKE_ANA_TOOL( m_pseudoTruthParticleCJetGetterTool, PseudoJetGetter) );
+       ASG_CHECK(m_pseudoTruthParticleCJetGetterTool.setProperty("InputContainer",  "TruthLabel" + m_ghostTruthInputCContainer));
+       ASG_CHECK(m_pseudoTruthParticleCJetGetterTool.setProperty("OutputContainer", "GhostCTruthParticles"+name()));
+       ASG_CHECK(m_pseudoTruthParticleCJetGetterTool.setProperty("Label", "Ghost"+ m_ghostTruthInputCContainer));
+       ASG_CHECK(m_pseudoTruthParticleCJetGetterTool.setProperty("SkipNegativeEnergy", true));
+       ASG_CHECK(m_pseudoTruthParticleCJetGetterTool.setProperty("GhostScale", m_ghostScale));
+       ASG_CHECK(m_pseudoTruthParticleCJetGetterTool.setProperty("OutputLevel", msg().level() ) );
+       ASG_CHECK(m_pseudoTruthParticleCJetGetterTool.retrieve());
+       getterArray.push_back(m_pseudoTruthParticleCJetGetterTool.getHandle());
+     //}
+    }
+        
 
   ATH_CHECK(getterArray.retrieve() );
   //    - create a Jet builder

--- a/Root/JetReclusteringTool.cxx
+++ b/Root/JetReclusteringTool.cxx
@@ -68,7 +68,7 @@ JetReclusteringTool::JetReclusteringTool(std::string name) :
   declareProperty("DoArea",                    m_doArea = false);
   declareProperty("AreaAttributes",            m_areaAttributes = "ActiveArea ActiveArea4vec");
   declareProperty("GhostTracksInputContainer", m_ghostTracksInputContainer = "");
-  declareProperty("GhostTracksVertexAssName",  m_ghostTracksVertexAssName = "");
+  declareProperty("GhostTracksVertexAssociationName",  m_ghostTracksVertexAssociationName = "");
   declareProperty("GhostScale",                m_ghostScale = 1e-20);
 
 }
@@ -163,7 +163,7 @@ StatusCode JetReclusteringTool::initialize(){
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("Label", "GhostTrack"));
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("SkipNegativeEnergy", true));
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("GhostScale", m_ghostScale));
-    ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("TrackVertexAssociation", m_ghostTracksVertexAssName));
+    ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("TrackVertexAssociation", m_ghostTracksVertexAssociationName));
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.setProperty("OutputLevel", msg().level() ) );
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.retrieve());
     getterArray.push_back(m_pseudoGhostTrackJetGetterTool.getHandle());

--- a/Root/LinkDef.h
+++ b/Root/LinkDef.h
@@ -1,6 +1,8 @@
+/*
+  Copyright (C) 2002-2017 CERN for the benefit of the ATLAS collaboration
+*/
+
 #include <JetReclustering/JetReclusteringAlgo.h>
-#include <JetReclustering/JetReclusteringTool.h>
-#include <JetReclustering/EffectiveRTool.h>
 
 #ifdef __CINT__
 
@@ -11,8 +13,5 @@
 
 /* Add a pragma link for any EventLoop algorithm */
 #pragma link C++ class JetReclusteringAlgo+;
-#pragma link C++ class JetReclusteringTool+;
-#pragma link C++ class EffectiveRTool+;
 
-#pragma link C++ class IJetReclusteringTool+;
 #endif


### PR DESCRIPTION
Hey Giordon,

A while back you helped add ghost track association to this package.  I updated it to allow ghost association of truth b/c hadrons.  There were some updates to the master that didn't propagate to the ghostTracks branch, but I believe I took care of that.  Let me know if there's a problem!  One major thing to note is that the CMakeList currently in the master did not match what was in the 21.2 athena cache.  This caused some compilation issues, so I commited the 21.2 version.

-Mazin