### PR TITLE
Ghost tracks and truth v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ atlas_depends_on_subdirs(
    Control/AthToolSupport/AsgTools
    Reconstruction/Jet/JetInterface
    Reconstruction/Jet/JetRec
+   Reconstruction/Jet/JetRecTools
    ${extra_deps}
    Event/xAODJet )
 
@@ -37,7 +38,7 @@ else()
    atlas_add_library( JetReclusteringLib
       JetReclustering/*.h Root/*.cxx
       PUBLIC_HEADERS JetReclustering
-      LINK_LIBRARIES AsgTools JetInterface JetRecLib
+      LINK_LIBRARIES AsgTools JetInterface JetRecLib JetRecToolsLib
       PRIVATE_LINK_LIBRARIES xAODJet xAODRootAccess )
 
    atlas_add_component( JetReclustering

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ if( XAOD_STANDALONE )
       Reconstruction/Jet/JetSubStructureMomentTools )
 else()
    set( extra_deps PRIVATE Control/xAODRootAccess Control/AthenaBaseComps
-      PhysicsAnalysis/POOLRootAccess GaudiKernel )
+      PhysicsAnalysis/POOLRootAccess GaudiKernel
+      Reconstruction/Jet/JetRecTools )
 endif()
 
 # The dependencies of the package:
@@ -18,7 +19,6 @@ atlas_depends_on_subdirs(
    Control/AthToolSupport/AsgTools
    Reconstruction/Jet/JetInterface
    Reconstruction/Jet/JetRec
-   Reconstruction/Jet/JetRecTools
    ${extra_deps}
    Event/xAODJet )
 

--- a/Root/JetReclusteringTool.cxx
+++ b/Root/JetReclusteringTool.cxx
@@ -23,7 +23,9 @@
 #include "JetRec/JetFinder.h"
 #include "JetRec/JetTrimmer.h"
 #include "JetRec/JetPseudojetRetriever.h"
+#ifndef XAOD_STANDALONE
 #include "JetRecTools/TrackPseudoJetGetter.h"
+#endif
 #include "JetReclustering/EffectiveRTool.h"
 #include "JetSubStructureMomentTools/JetChargeTool.h"
 #include "JetSubStructureMomentTools/JetPullTool.h"
@@ -157,7 +159,7 @@ StatusCode JetReclusteringTool::initialize(){
   ASG_CHECK(m_pseudoJetGetterTool.setProperty("OutputLevel", msg().level() ) );
   ASG_CHECK(m_pseudoJetGetterTool.retrieve());
   getterArray.push_back(m_pseudoJetGetterTool.getHandle());
-
+  #ifndef XAOD_STANDALONE
   //    - do we need ghost tracks too?
   if(!m_ghostTracksInputContainer.empty()){
     ATH_MSG_INFO( "GhostTracks PseudoJet Builder initializing..." );
@@ -176,6 +178,9 @@ StatusCode JetReclusteringTool::initialize(){
     ASG_CHECK(m_pseudoGhostTrackJetGetterTool.retrieve());
     getterArray.push_back(m_pseudoGhostTrackJetGetterTool.getHandle());
   }
+  #else
+  ATH_MSG_INFO( "Ghost track association is ATHENA ONLY, setting the option is doing nothing." );
+  #endif
   if(!m_ghostTruthInputBContainer.empty()){
        ATH_MSG_INFO( "GhostTracks PseudoJet Builder initializing..." );
        ASG_CHECK( ASG_MAKE_ANA_TOOL( m_pseudoTruthParticleBJetGetterTool, PseudoJetGetter) );


### PR DESCRIPTION
Added preprocessor directives.  I'm not very familiar with this, so please let me know if this looks incorrect to you!  It compiles and runs in the athena derivation and now compiles just fine in AnalysisBase.  If I understand correctly, the code should now ignore the track association stuff if it's not AthAnalysis (which I think is what XAOD_STANDALONE means).